### PR TITLE
Enable inner parameters in a string

### DIFF
--- a/test.js
+++ b/test.js
@@ -58,12 +58,24 @@ describe("json-template", function() {
       assert.equal(template({ unknownParam: "baz" }), "bar:baz");
     });
 
+    it("should compute template for a string with inner parameter", function() {
+      var template = parse("Hello {{foo}}, how are you ?");
+      assert.deepEqual(template.parameters, [{ key: "foo" }]);
+      assert.equal(template({ foo: "john" }), "Hello john, how are you ?");
+    });
+
   });
 
 
   // This section tests that the parse function recursively
   // traverses objects, and applies the string templating correctly.
   describe("objects", function() {
+
+    it("should compute template with an object that has inner parameter", function() {
+      var template = parse({ title: "Hello {{foo}}, how are you ?" });
+      assert.deepEqual(template.parameters, [{ key: "foo" }]);
+      assert.deepEqual(template({ foo: "john" }), { title: "Hello john, how are you ?" });
+    });
 
     it("should compute template with an object", function() {
       var template = parse({ title: "{{foo}}" });


### PR DESCRIPTION
This PR intends to add inner parameter support.

Here is an example:
```javascript
var parse    = require("json-templates"),
    template = parse("Hello {{name:Chris}}");

console.log(template.parameters); // Prints [{ key: "name" }]
console.log(template({ name: "Curran" })); // Prints "Hello Curran"
``` 

_Note:_ To avoid calling `str.match(regex)` twice, I updated the prototype of the function named `Parameter` to accept the result of the match call instead of a string.