### PR TITLE
Added support for templatable keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,18 +86,18 @@ function parseObject(object){
 
   var children = Object.keys(object).map(function (key){
     return {
-      key: key,
-      template: parse(object[key])
+      keyTemplate: parse(key),
+      valueTemplate: parse(object[key])
     };
   });
 
   return Template(function (context){
     return children.reduce(function (newObject, child){
-      newObject[child.key] = child.template(context);
+      newObject[child.keyTemplate(context)] = child.valueTemplate(context);
       return newObject;
     }, {});
   }, children.reduce(function (parameters, child){
-    return parameters.concat(child.template.parameters);
+      return parameters.concat(child.valueTemplate.parameters.concat(child.keyTemplate.parameters));
   }, []));
 
 }

--- a/test.js
+++ b/test.js
@@ -125,6 +125,46 @@ describe("json-template", function() {
 
     });
 
+    it("should compute template keys", function() {
+
+      var template = parse({
+        body: {
+          "A simple {{message}} to": "{{foo}}"
+        }
+      });
+
+      assert.deepEqual(template.parameters, [
+        { key: "foo" },
+        { key: "message"}
+      ]);
+
+      assert.deepEqual(template({ foo: "bar", message: "hello" }), {
+        body: {
+          "A simple hello to": "bar"
+        }
+      });
+    });
+
+    it("should compute template keys with default value", function() {
+
+      var template = parse({
+        body: {
+          "A simple {{message:hello}} to": "{{foo}}"
+        }
+      });
+
+      assert.deepEqual(template.parameters, [
+        { key: "foo" },
+        { key: "message", defaultValue: "hello"}
+      ]);
+
+      assert.deepEqual(template({ foo: "bar" }), {
+        body: {
+          "A simple hello to": "bar"
+        }
+      });
+    });
+
   });
 
 


### PR DESCRIPTION
This PR is intended to fix **Enable templating for keys** #2.

- Added 2 new tests that verifies:
  - Template keys
  - Template keys with default value
- Call `parse` on the key and the value in case of an object